### PR TITLE
fix: Proxy `vitest/suite`

### DIFF
--- a/.changeset/pretty-eagles-divide.md
+++ b/.changeset/pretty-eagles-divide.md
@@ -1,0 +1,9 @@
+---
+"vitest-plugin-vis": patch
+---
+
+Proxy `vitest/suite`.
+
+This fix the warning message `Module "util" has been externalized for browser compatibility.` when it is loaded in the browser.
+
+Fixes [#101](https://github.com/repobuddy/storybook-addon-vis/issues/101).

--- a/packages/vitest-plugin-vis/src/client/ctx.ts
+++ b/packages/vitest-plugin-vis/src/client/ctx.ts
@@ -1,4 +1,4 @@
-import { getCurrentTest } from 'vitest/suite'
+import { getCurrentTest } from './vitest_suite_proxy.ts'
 
 export const ctx = {
 	getCurrentTest,

--- a/packages/vitest-plugin-vis/src/client/vitest_suite_proxy.ts
+++ b/packages/vitest-plugin-vis/src/client/vitest_suite_proxy.ts
@@ -1,0 +1,9 @@
+let vitestSuite: Awaited<typeof import('vitest/suite')>
+
+if ((globalThis as any).__vitest_browser__) {
+	import('vitest/suite').then((m) => {
+		vitestSuite = m
+	})
+}
+
+export const getCurrentTest = () => vitestSuite?.getCurrentTest()


### PR DESCRIPTION
This fix the warning message `Module "util" has been externalized for browser compatibility.` when it is loaded in the browser.

Fixes [#101](https://github.com/repobuddy/storybook-addon-vis/issues/101).