### PR TITLE
Allow "platform" config option to be set explicitly

### DIFF
--- a/packages/storybook-addon-vis/readme.md
+++ b/packages/storybook-addon-vis/readme.md
@@ -97,6 +97,7 @@ export default defineConfig({
 			snapshotRootDir: '__vis__',
 			customizeSnapshotSubpath: (subpath) => trimCommonFolder(subpath),
 			customizeSnapshotId: (id, index) => `${id}-${index}`,
+			platform: undefined, // if undefined this gets set internally for use in the baseline snapshot path.
 			// pixelmatch or ssim.js options, depending on `comparisonMethod`.
 			diffOptions: undefined,
 			failureThresholdType: 'pixel',

--- a/packages/vitest-plugin-vis/readme.md
+++ b/packages/vitest-plugin-vis/readme.md
@@ -65,7 +65,8 @@ export default defineConfig({
 			customizeSnapshotSubpath: (subpath) => trimCommonFolder(subpath),
 			customizeSnapshotId: (id, index) => `${id}-${index}`,
 			platform: undefined, // if undefined this gets set internally for use in the baseline snapshot path.
-			diffOptions: undefined, // pixelmatch options
+			// pixelmatch or ssim.js options, depending on `comparisonMethod`.
+			diffOptions: undefined,
 			failureThresholdType: 'pixel',
 			failureThreshold: 0,
 			timeout: 5000 // 30000 on CI

--- a/packages/vitest-plugin-vis/readme.md
+++ b/packages/vitest-plugin-vis/readme.md
@@ -64,6 +64,7 @@ export default defineConfig({
 			snapshotRootDir: '__vis__',
 			customizeSnapshotSubpath: (subpath) => trimCommonFolder(subpath),
 			customizeSnapshotId: (id, index) => `${id}-${index}`,
+			platform: undefined, // if undefined this gets set internally for use in the baseline snapshot path.
 			diffOptions: undefined, // pixelmatch options
 			failureThresholdType: 'pixel',
 			failureThreshold: 0,

--- a/packages/vitest-plugin-vis/src/config/types.ts
+++ b/packages/vitest-plugin-vis/src/config/types.ts
@@ -15,6 +15,14 @@ export type VisOptions<M extends ComparisonMethod = 'pixel'> = ImageSnapshotTime
 		 */
 		preset?: 'manual' | 'auto' | 'none' | undefined
 		/**
+		 * The name of the subdirectory that the baseline snapshots get saved in.
+		 *
+		 * <snapshotRootDir>/<platform>/<snapshotSubpath>/<snapshotId>.png
+		 *
+		 * Default: undefined
+		 */
+		platform?: string | undefined
+		/**
 		 * The snapshot folder relative to the root of the project.
 		 *
 		 * Default: `__vis__`

--- a/packages/vitest-plugin-vis/src/config/vis.spec.ts
+++ b/packages/vitest-plugin-vis/src/config/vis.spec.ts
@@ -9,6 +9,13 @@ it('can be used with zero config', () => {
 	expect(vis()).toBeDefined()
 })
 
+it('can set the platform', () => {
+	vis({ platform: 'custom' })
+	expect(visContext.__test__getOptions()).toEqual({
+		platform: 'custom',
+	})
+})
+
 it('can customize snapshot root directory', () => {
 	vis({ snapshotRootDir: 'custom' })
 	expect(visContext.__test__getOptions()).toEqual({

--- a/packages/vitest-plugin-vis/src/server/vis_context.logic.ts
+++ b/packages/vitest-plugin-vis/src/server/vis_context.logic.ts
@@ -104,10 +104,10 @@ export function createVisContext() {
 	return context
 }
 
-async function setupState(suite: PartialBrowserCommandContext, visOptions: Pick<VisOptions, 'snapshotRootDir'>) {
+async function setupState(suite: PartialBrowserCommandContext, visOptions: Pick<VisOptions, 'snapshotRootDir' | 'platform'>) {
 	const snapshotRootDir = resolveSnapshotRootDir(visOptions)
 	const projectPath = suite.project.config.root
-	const platform = ctx.getSnapshotPlatform()
+	const platform = visOptions.platform ?? ctx.getSnapshotPlatform()
 
 	const state = {
 		projectPath,

--- a/packages/vitest-plugin-vis/src/server/vis_context.logic.ts
+++ b/packages/vitest-plugin-vis/src/server/vis_context.logic.ts
@@ -104,7 +104,10 @@ export function createVisContext() {
 	return context
 }
 
-async function setupState(suite: PartialBrowserCommandContext, visOptions: Pick<VisOptions, 'snapshotRootDir' | 'platform'>) {
+async function setupState(
+	suite: PartialBrowserCommandContext,
+	visOptions: Pick<VisOptions, 'snapshotRootDir' | 'platform'>,
+) {
 	const snapshotRootDir = resolveSnapshotRootDir(visOptions)
 	const projectPath = suite.project.config.root
 	const platform = visOptions.platform ?? ctx.getSnapshotPlatform()


### PR DESCRIPTION
Closes https://github.com/repobuddy/storybook-addon-vis/issues/152

Allows a `platform` config option to be set to determine the subdirectory name where the baseline snapshots are located