### PR TITLE
chore(ci): pin the shared workflows to @v1

### DIFF
--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -5,6 +5,6 @@ jobs:
   docgen:
     permissions:
       contents: write
-    uses: repobuddy/.github/.github/workflows/pnpm-docs.yml@main
+    uses: repobuddy/.github/.github/workflows/pnpm-docs.yml@v1
     with:
       publish-dir: ./packages/storybook-addon-vis/storybook-static

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -47,7 +47,7 @@ jobs:
         run: pnpm install
 
       - name: Install playwright browsers
-        uses: repobuddy/.github/.github/actions/setup-playwright@main
+        uses: repobuddy/.github/.github/actions/setup-playwright@v1
 
       - name: Verify
         uses: nick-fields/retry@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         run: pnpm install
 
       - name: Install playwright browsers
-        uses: repobuddy/.github/.github/actions/setup-playwright@main
+        uses: repobuddy/.github/.github/actions/setup-playwright@v1
 
       - name: Verify
         uses: nick-fields/retry@v4
@@ -53,14 +53,14 @@ jobs:
             */*/__vis__/**/__results__
 
   release:
-    uses: repobuddy/.github/.github/workflows/pnpm-release-changeset.yml@main
+    uses: repobuddy/.github/.github/workflows/pnpm-release-changeset.yml@v1
     needs: verify
     secrets: inherit
 
   docgen:
     permissions:
       contents: write
-    uses: repobuddy/.github/.github/workflows/pnpm-docs.yml@main
+    uses: repobuddy/.github/.github/workflows/pnpm-docs.yml@v1
     needs: release
     if: github.ref == 'refs/heads/main' && needs.release.outputs.published == 'true'
     with:

--- a/.github/workflows/update-snapshot.yml
+++ b/.github/workflows/update-snapshot.yml
@@ -34,7 +34,7 @@ jobs:
         run: pnpm install
 
       - name: Install playwright browsers
-        uses: repobuddy/.github/.github/actions/setup-playwright@main
+        uses: repobuddy/.github/.github/actions/setup-playwright@v1
 
       - run: ${{ inputs.build-command }}
       - run: ${{ inputs.update-snapshot-command }}


### PR DESCRIPTION
This repo's release path is broken right now, and this fixes it.

`repobuddy/.github` pinned at `@main` meant an auto-merged Renovate bump there reached this repo instantly. That happened on 2026-08-12: [repobuddy/.github#42](https://github.com/repobuddy/.github/pull/42) moved `pnpm-release-changeset.yml` to `changesets/action@v2`, which validates the consumer's `@changesets/cli` major and aborts on v2:

```
Error: This version of the Changesets action is designed to work with Changesets CLI v3.
Changesets CLI v2 is not supported; use Changesets action v1 instead.
```

Nothing failed visibly here only because this repo has not released since. The next release would have.

`repobuddy/.github` is now tagged with two parallel lines:

| Line | action | CLI |
| --- | --- | --- |
| `@v1` | `changesets/action@v1` | v2 |
| `@v2` | `changesets/action@v2` | v3 |

This repo is on `@changesets/cli ^2.29.8` → **`@v1`**. Move to `@v2` only alongside a CLI v3 upgrade here; they are a matched pair.

Composite action refs are pinned too — a tagged workflow ref that still pulls a floating `setup-playwright@main` is only half a pin.

There is also a new secretless `pnpm-release-changeset-oidc.yml` on both lines (built-in `GITHUB_TOKEN` + npm trusted publishing instead of `CI_GITHUB_TOKEN` + `NPM_TOKEN`). Not adopted here — that needs a trusted publisher registered per package first.