### PR TITLE
ci: pin the shared workflows to @v2, and finish the changesets v3 move

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
+	"$schema": "https://unpkg.com/@changesets/config@4.0.0/schema.json",
 	"___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
 		"onlyUpdatePeerDependentsWhenOutOfRange": true,
 		"updateInternalDependents": "always"

--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -5,6 +5,6 @@ jobs:
   docgen:
     permissions:
       contents: write
-    uses: repobuddy/.github/.github/workflows/pnpm-docs.yml@main
+    uses: repobuddy/.github/.github/workflows/pnpm-docs.yml@v2
     with:
       publish-dir: ./packages/storybook-addon-vis/storybook-static

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -47,7 +47,7 @@ jobs:
         run: pnpm install
 
       - name: Install playwright browsers
-        uses: repobuddy/.github/.github/actions/setup-playwright@main
+        uses: repobuddy/.github/.github/actions/setup-playwright@v2
 
       - name: Verify
         uses: nick-fields/retry@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         run: pnpm install
 
       - name: Install playwright browsers
-        uses: repobuddy/.github/.github/actions/setup-playwright@main
+        uses: repobuddy/.github/.github/actions/setup-playwright@v2
 
       - name: Verify
         uses: nick-fields/retry@v4
@@ -53,14 +53,14 @@ jobs:
             */*/__vis__/**/__results__
 
   release:
-    uses: repobuddy/.github/.github/workflows/pnpm-release-changeset.yml@main
+    uses: repobuddy/.github/.github/workflows/pnpm-release-changeset.yml@v2
     needs: verify
     secrets: inherit
 
   docgen:
     permissions:
       contents: write
-    uses: repobuddy/.github/.github/workflows/pnpm-docs.yml@main
+    uses: repobuddy/.github/.github/workflows/pnpm-docs.yml@v2
     needs: release
     if: github.ref == 'refs/heads/main' && needs.release.outputs.published == 'true'
     with:

--- a/.github/workflows/update-snapshot.yml
+++ b/.github/workflows/update-snapshot.yml
@@ -34,7 +34,7 @@ jobs:
         run: pnpm install
 
       - name: Install playwright browsers
-        uses: repobuddy/.github/.github/actions/setup-playwright@main
+        uses: repobuddy/.github/.github/actions/setup-playwright@v2
 
       - run: ${{ inputs.build-command }}
       - run: ${{ inputs.update-snapshot-command }}

--- a/package.json
+++ b/package.json
@@ -59,6 +59,6 @@
 	},
 	"packageManager": "pnpm@11.22.0",
 	"engines": {
-		"node": ">=22.6.0"
+		"node": "^22.11 || ^24 || >=26"
 	}
 }


### PR DESCRIPTION
Fixes the red `release` job on `main`.

## What broke

`changesets/action` v2 renamed its inputs and refuses to run against `@changesets/cli` v2. The shared release workflow was pinned at `@main` in `repobuddy/.github` — which is *that* repo's **v1 line** — where Renovate had already auto-merged the action to v2.1.1, so the mismatch arrived here uninvited:

```
Error: The following inputs have been renamed:
- "publish" -> "publish-script"
- "version" -> "version-script"
- "commit" -> "commit-mesage"
```

## What this does

Renovate has since landed `@changesets/cli` v3 (5467b92) and `@changesets/changelog-github` v1 (23a5ad0) on `main`. This PR is what those bumps left undone:

- **All `repobuddy/.github` refs `@main` → `@v2`.** That repo keeps parallel v1/v2 lines; `v2` is the one pairing `changesets/action@v2` with CLI v3. `pnpm-docs.yml` and `setup-playwright` are byte-identical between the two, so only the release path changes behavior.
- **`.changeset/config.json` schema → `@changesets/config@4.0.0`.** Every key in use survives into v4 unchanged, including both `___experimentalUnsafeOptions_*` keys.
- **root `engines.node` `>=22.6.0` → `^22.11 || ^24 || >=26`**, the v3 floor. The root package is private, so nothing published changes.

Going forward rather than pinning the action back to `@v1`: CLI v2 also hits the npm 12 `npm info --json` change, where `.versions` reads `undefined`, every version looks unpublished, and the release republishes into an E403.

Supersedes #842, which pinned to `@v1` — the hold rather than the upgrade.

## Verified

- `pnpm exec changeset status` runs clean on cli 3.0.1
- no `changeset tag` or `--sinceMaster` callers; nothing else wraps `changeset version`
- lockfile unchanged against `main`

No changeset file — CI and devDependency metadata only.

Paired with repobuddy/.github#50, which puts that repo's `main` back on `changesets/action@v1` for the consumers still on CLI v2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)