### PR TITLE
fix(ci): grant the release caller the scopes the shared workflow declares

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,13 @@ jobs:
             */*/__vis__/**/__results__
 
   release:
+    # Declaring permissions replaces the default set, so every scope the called
+    # workflow declares must be listed here — unlisted ones drop to none, and a
+    # callee asking for more than the caller holds fails the run at startup.
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
     uses: repobuddy/.github/.github/workflows/pnpm-release-changeset.yml@v2
     needs: verify
     secrets: inherit


### PR DESCRIPTION
Fixes the `startup_failure` on `main` from #844 (run [32346886564](https://github.com/repobuddy/visual-testing/actions/runs/32346886564)).

## What broke

Pinning to `@v2` did not just rename the action inputs — it moved to the workflow built for `changesets/action` v2, which pushes release commits and tags through the GitHub API rather than the git CLI (`push-with-git-cli` defaults to `false`). It therefore declares:

```yaml
permissions:
  id-token: write
  contents: write
  pull-requests: write
```

`release.yml` granted `id-token: write` and `contents: read` at the top level. Declaring `permissions:` at all replaces the default set, so `pull-requests` was `none`. A called workflow cannot hold more than its caller, and the run fails at startup — before any job, which is why there are no logs and no annotations.

## What this does

Declares the three scopes on the `release` job itself, leaving the top-level `contents: read` in place for `verify`.

`docgen` needs no change: `pnpm-docs.yml` declares no `permissions` block, so its job-level `contents: write` already covers it.

## Verifying

The failure is only observable on a push to `main`, so this cannot be proven green from a PR — the next push after merge is the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)