### PR TITLE
ci: release through the OIDC variant of the shared workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,12 +57,14 @@ jobs:
     # workflow declares must be listed here — unlisted ones drop to none, and a
     # callee asking for more than the caller holds fails the run at startup.
     permissions:
+      # Mints the OIDC token npm exchanges for short-lived publish credentials.
       id-token: write
+      # Lets changesets/action push the version branch and tags.
       contents: write
+      # Lets changesets/action open the "version packages" PR.
       pull-requests: write
-    uses: repobuddy/.github/.github/workflows/pnpm-release-changeset.yml@v2
+    uses: repobuddy/.github/.github/workflows/pnpm-release-changeset-oidc.yml@v2
     needs: verify
-    secrets: inherit
 
   docgen:
     permissions:


### PR DESCRIPTION
## ⚠️ Do not merge until trusted publishers are registered

Publishing fails with an auth error until **both** published packages have a trusted publisher registered at `npmjs.com/package/<name>/access`, naming this repo and the **caller** workflow filename — `release.yml`, not the reusable workflow's name:

- [ ] [`storybook-addon-vis`](https://www.npmjs.com/package/storybook-addon-vis/access)
- [ ] [`vitest-plugin-vis`](https://www.npmjs.com/package/vitest-plugin-vis/access)

I cannot do this part — it needs npm account access.

## Why

`pnpm-release-changeset.yml@v2`, adopted in #844, gets as far as `changesets/action` and then fails:

```
Error: The GITHUB_TOKEN environment variable is set and does not match
the "github-token" input.
```

That variant passes `CI_GITHUB_TOKEN` as both the `github-token` input and the step's `GITHUB_TOKEN` env var. They are written as the same expression and the action still reads them as unequal — `core.getInput()` trims, `process.env` does not, and that org secret was created in 2022. `repobuddy/repobuddy` is the only repo on `@v2` that releases successfully, and it uses the OIDC variant, so the CI_GITHUB_TOKEN variant appears never to have worked.

The OIDC variant passes **no** `github-token` input, so the env var matches the action's own `${{ github.token }}` default and the check passes. It is also what the shared repo's README tells consumers to prefer: npm credentials are minted per run rather than living in a long-lived `NPM_TOKEN`, and publishes carry provenance attestations.

## What changes

- `release` calls `pnpm-release-changeset-oidc.yml@v2`
- `secrets: inherit` dropped — the callee reads no repo secrets now
- permissions unchanged from #845, just commented

## Known trade-off, and why it costs nothing here

A PR opened with the built-in `GITHUB_TOKEN` does not trigger `on: pull_request`, so future "Version Packages" PRs get no status checks. `main` has no branch protection and no required checks, so nothing blocks on them.

Worth knowing: this repo does **not** carry `branches-ignore: ['changeset-release/*']` on `pull-request.yml`, contrary to what the shared README assumes about consumers. It stops mattering under OIDC — the checks simply never start — but the README's claim is wrong for this repo.

## After merging

Once a release publishes successfully, `NPM_TOKEN` and `CI_GITHUB_TOKEN` can be deleted from the org secrets — but only after every consumer has migrated, since both are org-wide and other repos still use them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)