### PR TITLE
fix(vitest-plugin-vis): show snapshot paths relative to the project root

### DIFF
--- a/.changeset/blue-pugs-smile.md
+++ b/.changeset/blue-pugs-smile.md
@@ -1,0 +1,7 @@
+---
+'vitest-plugin-vis': patch
+---
+
+Show snapshot paths in failure messages relative to the project root (`./__vis__/...`) instead of absolute.
+
+Editors and terminals resolve the relative path just as well, and the output no longer leaks the local absolute path when a failure is pasted into a bug report. Paths outside the project root stay absolute. Filesystem operations are unaffected and still resolve to absolute paths.

--- a/packages/vitest-plugin-vis/src/client/expect/to_match_image_snapshot.spec.tsx
+++ b/packages/vitest-plugin-vis/src/client/expect/to_match_image_snapshot.spec.tsx
@@ -88,6 +88,9 @@ it('fails when the image is different', async ({ expect }) => {
 			},
 			(error) => {
 				expect(error.message).toMatch(/Expected image to match but was differ by \d+ pixels./)
+				expect(error.message).toMatch(/Expected:\s+\.\/__vis__\/.*\.png/)
+				expect(error.message).toMatch(/Actual:\s+\.\/__vis__\/.*\.png/)
+				expect(error.message).toMatch(/Difference:\s+\.\/__vis__\/.*\.png/)
 			},
 		)
 })
@@ -298,6 +301,8 @@ it('should fail with additional info when it does not fail with expectToFail', a
 				expect(error.message).toMatch(/Snapshot .* matched but expected to fail/)
 				expect(error.message).toMatch(/Options:\s+failureThreshold: \d+ pixels/)
 				expect(error.message).toMatch(/Diff:\s+\d+ pixels/)
+				expect(error.message).toMatch(/Expected:\s+\.\/__vis__\/.*\.png/)
+				expect(error.message).toMatch(/Actual:\s+\.\/__vis__\/.*\.png/)
 			},
 		)
 })

--- a/packages/vitest-plugin-vis/src/client/snapshot/compare_image_snapshot.logic.ts
+++ b/packages/vitest-plugin-vis/src/client/snapshot/compare_image_snapshot.logic.ts
@@ -1,3 +1,4 @@
+import { isAbsolute, relative, resolve } from 'pathe'
 import type { ToMatchImageSnapshotOptions } from '../../shared/types.ts'
 
 export function prettifyOptions(options: ToMatchImageSnapshotOptions<any> | undefined) {
@@ -12,4 +13,20 @@ export function prettifyOptions(options: ToMatchImageSnapshotOptions<any> | unde
 	]
 		.filter(Boolean)
 		.join('\n                ')
+}
+
+/**
+ * Formats a snapshot path for display in a failure message.
+ *
+ * Paths within the project root are shown relative to it so that the failure output can be shared
+ * verbatim without leaking the local absolute path, while remaining clickable in editors and terminals.
+ * Paths outside the project root stay absolute, as a `../../..` chain is neither shorter nor clearer.
+ */
+export function formatSnapshotPath(projectRoot: string, path: string) {
+	const absolutePath = resolve(projectRoot, path)
+	const relativePath = relative(projectRoot, absolutePath)
+	if (!relativePath || relativePath === '..' || relativePath.startsWith('../') || isAbsolute(relativePath)) {
+		return absolutePath
+	}
+	return `./${relativePath}`
 }

--- a/packages/vitest-plugin-vis/src/client/snapshot/compare_image_snapshot.ts
+++ b/packages/vitest-plugin-vis/src/client/snapshot/compare_image_snapshot.ts
@@ -10,7 +10,7 @@ import type { ImageSnapshotComparisonInfo, ToMatchImageSnapshotOptions } from '.
 import { toDataURL, toImageData } from '../external/browser/image_data.ts'
 import { server } from '../external/vitest/vitest_browser_context_proxy.ts'
 import { alignImagesToSameSize } from '../image/align_images.ts'
-import { prettifyOptions } from './compare_image_snapshot.logic.ts'
+import { formatSnapshotPath, prettifyOptions } from './compare_image_snapshot.logic.ts'
 
 export async function compareImageSnapshot(
 	commands: BrowserCommands & PrepareImageSnapshotComparisonCommand & ImageSnapshotNextIndexCommand,
@@ -31,7 +31,7 @@ export async function compareImageSnapshot(
 			dedent`Snapshot \`${taskId}\` has no baseline image. Please review the new snapshot and update the baseline image.
 
 				Options:    ${prettifyOptions(options)}
-				Actual:     ${resolve(info.projectRoot, info.resultPath)}`,
+				Actual:     ${formatSnapshotPath(info.projectRoot, info.resultPath)}`,
 		)
 	}
 
@@ -55,8 +55,8 @@ export async function compareImageSnapshot(
 							Options:    ${prettifyOptions(options)}
 							Diff:       ${options.failureThresholdType === 'percent' ? `${diffAmount}%` : `${diffAmount} pixels`}
 
-							Expected:   ${resolve(info.projectRoot, info.baselinePath)}
-							Actual:     ${resolve(info.projectRoot, info.resultPath)}`,
+							Expected:   ${formatSnapshotPath(info.projectRoot, info.baselinePath)}
+							Actual:     ${formatSnapshotPath(info.projectRoot, info.resultPath)}`,
 			)
 		}
 		return
@@ -85,9 +85,9 @@ export async function compareImageSnapshot(
 
 					Options:    ${prettifyOptions(options)}
 
-					Expected:   ${resolve(info.projectRoot, info.baselinePath)}
-					Actual:     ${resolve(info.projectRoot, info.resultPath)}
-					Difference: ${resolve(info.projectRoot, info.diffPath)}`,
+					Expected:   ${formatSnapshotPath(info.projectRoot, info.baselinePath)}
+					Actual:     ${formatSnapshotPath(info.projectRoot, info.resultPath)}
+					Difference: ${formatSnapshotPath(info.projectRoot, info.diffPath)}`,
 	)
 }
 

--- a/packages/vitest-plugin-vis/src/client/snapshot/compare_image_snapshot.unit.ts
+++ b/packages/vitest-plugin-vis/src/client/snapshot/compare_image_snapshot.unit.ts
@@ -1,5 +1,5 @@
-import { it } from 'vitest'
-import { prettifyOptions } from './compare_image_snapshot.logic.ts'
+import { describe, it } from 'vitest'
+import { formatSnapshotPath, prettifyOptions } from './compare_image_snapshot.logic.ts'
 
 it('returns none when no options', ({ expect }) => {
 	expect(prettifyOptions(undefined)).toBe('none')
@@ -22,4 +22,32 @@ it('stringify diffOptions', ({ expect }) => {
 	expect(prettifyOptions({ diffOptions: { threshold: 0.1 } })).toMatch(
 		/failureThreshold: 0 pixels\s{17}comparisonMethod: pixel\s{17}diffOptions: {"threshold":0.1}/,
 	)
+})
+
+describe('formatSnapshotPath', () => {
+	it('formats a path within the project root as a relative path', ({ expect }) => {
+		expect(formatSnapshotPath('/home/me/project', '__vis__/local/__baselines__/some.spec.tsx/case-1.png')).toBe(
+			'./__vis__/local/__baselines__/some.spec.tsx/case-1.png',
+		)
+	})
+
+	it('does not leak the project root of an absolute path within the project', ({ expect }) => {
+		expect(formatSnapshotPath('/home/me/project', '/home/me/project/__vis__/local/case-1.png')).toBe(
+			'./__vis__/local/case-1.png',
+		)
+	})
+
+	it('keeps a path outside the project root absolute', ({ expect }) => {
+		expect(formatSnapshotPath('/home/me/project/packages/app', '../../__vis__/local/case-1.png')).toBe(
+			'/home/me/project/__vis__/local/case-1.png',
+		)
+	})
+
+	it('keeps the project root itself absolute', ({ expect }) => {
+		expect(formatSnapshotPath('/home/me/project', '.')).toBe('/home/me/project')
+	})
+
+	it('does not mistake a leading dot-dot in a filename for an escape', ({ expect }) => {
+		expect(formatSnapshotPath('/home/me/project', '..vis/case-1.png')).toBe('./..vis/case-1.png')
+	})
 })


### PR DESCRIPTION
Closes #93.

## The ask

> use relative path to project root for failed snapshots — instead of abs path.

Two motivations, pointing the same way: terminals and editors linkify a project-relative path fine, and an absolute path leaks `/home/<someone>/...` into any failure output pasted into an issue.

### The 2024 blocker is gone

The issue was parked on [microsoft/vscode#237086](https://github.com/microsoft/vscode/issues/237086) ("gitignored relative file link in Terminal not clickable"), with a note to fix it "once that is fixed and released". That issue closed `verified` in the **November 2025** milestone and has long since shipped stable, so the premise holds and the reason to wait is gone.

## The change

`compare_image_snapshot.ts` builds three failure messages — no baseline, matched-but-expected-to-fail, and mismatched. Every path in them was `resolve(info.projectRoot, info.<baseline|result|diff>Path)`. `info.*Path` is already project-relative; the `resolve()` was what made it absolute.

Those `Expected:` / `Actual:` / `Difference:` lines now go through a new `formatSnapshotPath` helper in `compare_image_snapshot.logic.ts`:

```
Expected:   ./__vis__/local/HD/__baselines__/client/expect/to_match_image_snapshot.spec.tsx/case-1.png
```

**Only the human-facing message strings changed.** The ~20 other `resolve(projectRoot, ...)` call sites are filesystem I/O — `writeSnapshot`, `tryReadFile`, playwright's screenshot `path`, `snapshot_path_limits.ts`, the globs in `vis_server_context.logic.ts` — and all stay absolute. The three `writeSnapshot` calls in this same file still use `resolve()`.

## Judgment calls

- **`./` prefix.** Both bare and `./`-prefixed paths linkify, but the prefix marks the path unambiguously as relative rather than a bare package-ish name, and it survives copy-paste into a shell.
- **Outside the project root** — reachable in a monorepo via a custom `snapshotRootDir` — falls back to absolute rather than emitting `../../../..` noise, which is neither shorter nor clearer.
- **Filenames beginning with `..`** (e.g. `..vis/`) are not mistaken for an escape; the check is `=== '..'` or `startsWith('../')`, not a bare `startsWith('..')`.

## Tests

- Five unit tests for `formatSnapshotPath` in `compare_image_snapshot.unit.ts`: relative-within-root, absolute-within-root (the leak case), outside-root fallback, the root itself, and the `..`-prefixed-filename edge case.
- `to_match_image_snapshot.spec.tsx` now asserts the actual `Expected:` / `Actual:` / `Difference:` lines are `./__vis__/…`-relative, on both the mismatch and the matched-but-expected-to-fail message. These assertions were confirmed to be genuinely exercised (deliberately breaking one fails the suite), not silently skipped by the specs' `hasImageSnapshot()` early return.

`storybook-addon-vis` surfaces no paths of its own — it renders these same messages from `vitest-plugin-vis` — so it is untouched. Its suite passes unchanged.

## Verification

- `pnpm build` — 7/7 tasks ✅
- `vitest-plugin-vis`: 182 passed | 4 skipped (playwright), 87 passed | 1 skipped (node), `tsc --noEmit` clean
- `storybook-addon-vis`: 83 passed
- `biome check` clean on all changed files

Changeset: patch for `vitest-plugin-vis`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1RSK6XtmajN5fASgJHqVb